### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ High Performance Computing Cluster Engineering Academy
 Collection of tools and code for evaluation testing of HPC orchestration solutions by HPCCEA summer
 students within Livermore Computing. These scripts and configuration files were written by HPCCEA summer students as part of their summer internship where they explore alternative solutions to our current HPC cluster management
 software. These scripts/configuration files range from using configuration management tools (Puppet,
-Chef, Ansible, Fabric, etc.) to scripting languages (Phython, BASH, Perl, etc.). Each year, new students
+Chef, Ansible, Fabric, etc.) to scripting languages (Python, BASH, Perl, etc.). Each year, new students
 will be added to the project and expand on previous years work.
 
 # RELEASE


### PR DESCRIPTION
Fixed typo in the name Python.